### PR TITLE
fix: 解决弹窗 'detail' 错写为 'title' 的 bug

### DIFF
--- a/src/windows/controller/uploader.js
+++ b/src/windows/controller/uploader.js
@@ -133,7 +133,7 @@ class UploaderWindow {
 
     if (res.length <= 0) {
       Tools.dialog(this.uploaderWindow, {
-        title: '没有可上传文件',
+        detail: '没有可上传文件',
       });
       return;
     }


### PR DESCRIPTION
上传单个非音乐文件的时候弹窗不显示文本，如图：
![Snipaste_2022-05-13_18-36-16](https://user-images.githubusercontent.com/35727398/168268572-abd2ee2a-dd0b-4ed0-b453-6b00c418a8e0.jpg)

