### PR TITLE
修复 Apple 芯片的 Mac 第一次登录无法上传的 bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "cloud-uploader",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "CC0-1.0",
       "dependencies": {
         "electron-clipboard-ex": "^1.3.3",

--- a/src/common/api.js
+++ b/src/common/api.js
@@ -26,6 +26,7 @@ class Api {
             return;
         }
         option.proxy = this.proxy;
+        this.cookie = this.getCookie(); // 重新获取cookie
         option.cookie = this.cookie;
 
         if (!CloudApi[name]) {

--- a/src/windows/views/uploader.html
+++ b/src/windows/views/uploader.html
@@ -15,7 +15,7 @@
         <!-- 上传区域 -->
         <div class="upload-block">
             <div style="cursor: pointer">
-                <a href="#" title="点击上次文件">
+                <a href="#" title="点击上传文件">
                     <img
                             id="openFileSelect"
                             class="upload-image"


### PR DESCRIPTION
Hello @lulu-ls ，感谢你的项目，让我能够在 Mac 上上传音乐到云盘🙏
我是 M 芯片的 Mac，发现第一次扫码登录后上传一直转圈圈。翻了 issue 评论区后才知道需要重启一下 app，果然就正常了。于是我就调试了一下，解决了这个问题。
![正常上传 cookie](https://github.com/lulu-ls/cloud-uploader/assets/8766034/bb04b74a-741c-4d6a-8209-b299b83f273c)
首先这是正常情况下的上传，可以看到 cookie 里面有许多项。但是我的 Mac 在第一次扫码登录成功上传后的 cookie 是下面这样。
![异常情况](https://github.com/lulu-ls/cloud-uploader/assets/8766034/31d7dc17-6e01-4471-b5aa-9ffd6d20bb01)
所以看起来是鉴权 cookie 丢失导致的上传失败。因为我不熟悉你的项目代码，所以直接在上传那里重新获取了一下最新的 cookie。这样的代码着实有点丑陋，你酌情处理这个 PR😂